### PR TITLE
fixes #10 - backend changes for displaying correct username instead o…

### DIFF
--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -15,7 +15,7 @@ class Form extends Component {
                 <option selected disabled hidden>Select a Username</option>
                 {Object.entries(this.props.names).map(name => (
                     <option key={shortid.generate()} value={name}>
-                        {name[0]}
+                        {name[1]}
                     </option>
                 ))};
         </select>


### PR DESCRIPTION
This fixes it in the UI.

From in issue: #9 : 
<img width="1007" alt="Screen Shot 2019-10-20 at 09 38 33" src="https://user-images.githubusercontent.com/9321510/67156866-6166a580-f324-11e9-9b4b-fcbbc5cc4c01.png">

to: 
<img width="1098" alt="Screen Shot 2019-10-20 at 10 27 41" src="https://user-images.githubusercontent.com/9321510/67156862-51e75c80-f324-11e9-9999-f94bb70d6caa.png">
