### PR TITLE
Stringify the object to make the log readable

### DIFF
--- a/src/components/GoogleLogin.js
+++ b/src/components/GoogleLogin.js
@@ -21,7 +21,7 @@ class GoogleLoginButton extends Component {
   }
 
   handleLoginFailure(r) {
-    console.error(`Failed to log in ${r}`);
+    console.error(`Failed to log in ${JSON.stringify(r)}`);
   }
 
   render() {


### PR DESCRIPTION
Before:
```
index.js:1437 Failed to log in [object object]
```

Now:

```
Failed to log in {"error":"idpiframe_initialization_failed","details":"Not a valid origin for the client: xxx }
```