### PR TITLE
Fix github actions deployment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,13 @@ jobs:
       - uses: actions/checkout@v2
       - name: Setup ENV
         run: |
-          echo $REACT_APP_BACKEND_URL > ./.env.prod
-          echo $REACT_APP_GOOGLE_CLIENT_ID >> ./.env.prod
+          echo REACT_APP_backend_url=$backend_url_prod > ./.env.prod
+          echo REACT_APP_google_client_id=$google_client_id_prod >> ./.env.prod
         env:
-          REACT_APP_BACKEND_URL: ${{ secrets.REACT_APP_PROD_BACKEND_URL }}
-          REACT_APP_GOOGLE_CLIENT_ID: ${{ secrets.REACT_APP_PROD_GOOGLE_CLIENT_ID }}
+          backend_url_prod: ${{ secrets.BACKEND_URL_PROD }}
+          google_client_id_prod: ${{ secrets.GOOGLE_CLIENT_ID_PROD }}
 
-      - name: Setup node dev
+      - name: Setup node instance
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}

--- a/README.md
+++ b/README.md
@@ -30,4 +30,16 @@ Now you should be to access the UI via http://localhost:3000
 
 ## Update secrets
 
-Secrets are added/deleted/updated in github.
+Secrets are added/deleted/updated in github action [secrets](https://github.com/codelabsab/timereport-ui/settings/secrets/actions).
+
+For prod secrets ends with `_prod` in the name.
+
+### Backend URL secret
+this secret is the URL to timereport-api. To find the URL it's easiest to login to AWS and find the api gateway.
+
+### Google client ID secret
+This secret is the google client id that we use to authenticate codelabs users via google auth.
+
+This is the current in use id for prod:
+https://console.cloud.google.com/apis/credentials/oauthclient/54600554888-jhtcn28sshqn0p2c115rokqr8q9lhoqa.apps.googleusercontent.com?authuser=1&project=timereport-login
+


### PR DESCRIPTION
Secrets are now in the repository instead of the organisation.
They are now named:
```
BACKEND_URL_PROD
GOOGLE_CLIENT_ID_PROD
```
Update documentation how to find them etc.

Fixes #41 